### PR TITLE
Discord Botで複数ユーザー・複数サーバーの設定を同時サポート (#1)

### DIFF
--- a/discord-bot/types.ts
+++ b/discord-bot/types.ts
@@ -18,6 +18,7 @@ export interface UserSettings {
   userId: string;
   channelId: string;
   conditions: NotificationCondition[];
+  lastNotified?: string;
 }
 
 export interface ScheduleMatch {


### PR DESCRIPTION
## 概要
- Issue #1「DiscordBotにて最後に実行された/watchコマンドしか保持されない」を修正
- userSettingsのキーを`userId`から`userId_guildId`形式に変更し、複数ユーザーが異なるサーバーで設定を保持可能に
- 全Discord botコマンドで適切なギルドID処理を追加

## 変更内容
- **キー形式変更**: `userSettings`で`${userId}_${guildId || 'dm'}`をユニークキーとして使用
- **ギルドID取得**: 全コマンドハンドラーでinteractionからの`guildId`取得を追加
- **DM対応**: `guildId`がnullの場合のDM用フォールバック（'dm'）を実装
- **型安全性**: `UserSettings`インターフェースに`lastNotified?: string`を追加
- **ログ改善**: ギルド情報を含むログ出力に改善
- **通知ループ**: 新しいキー形式に対応した通知チェック処理に更新

## テスト計画
- [ ] 同一サーバーで複数ユーザーの`/watch`コマンドをテスト
- [ ] 同一ユーザーが異なるサーバーで`/watch`コマンドをテスト
- [ ] 新しいキー形式での`/status`、`/stop`、`/test`コマンドをテスト
- [ ] 'dm'フォールバックでDM機能が動作することを確認
- [ ] 保存された全設定で通知配信が動作することを確認

## 修正前後の動作

### 修正前（❌ バグ）
```
ユーザーA: サーバー1で/watch → 設定が"userA"として保存
ユーザーB: サーバー2で/watch → 設定が"userB"として保存（userAを上書き）
ユーザーA: 設定が消失
```

### 修正後（✅ 修正済み）
```
ユーザーA: サーバー1で/watch → 設定が"userA_server1"として保存
ユーザーB: サーバー2で/watch → 設定が"userB_server2"として保存
ユーザーA: 設定が保持され、ユーザーBと独立して動作
```

Issue #1を解決

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>