### PR TITLE
fix: Discord Bot deployのentrypointをwebhook.tsからmain.tsに修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,6 @@ jobs:
         uses: denoland/deployctl@v1
         with:
           project: "qnaiv-splatoon3-s-12"
-          entrypoint: "discord-bot/webhook.ts"
+          entrypoint: "discord-bot/main.ts"
           
           

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,12 @@ REQUIREMENTS.md
 DISCORD_BOT_PLAN.md
 
 public/
+
+# Serena MCP files
+.serena/cache/
+.serena/logs/
+.serena/*.log
+
+# Keep memories and project config
+# .serena/memories/
+# .serena/project.yml

--- a/.serena/memories/code_style_conventions.md
+++ b/.serena/memories/code_style_conventions.md
@@ -1,0 +1,50 @@
+# Code Style and Conventions
+
+## TypeScript/JavaScript Style
+- **ESLint Configuration**: Uses @eslint/js with TypeScript support
+- **Prettier Formatting**: 
+  - Single quotes preferred
+  - Semicolons required
+  - 80 character line width
+  - 2-space indentation (no tabs)
+  - ES5 trailing commas
+- **Unused Variables**: Error level, use `_` prefix for ignored args
+- **TypeScript**: `any` type generates warnings, prefer-const enforced
+
+## File Organization
+- React components in `src/components/`
+- Custom hooks in `src/hooks/`
+- Utilities in `src/utils/`
+- Type definitions in `src/types/`
+- Discord bot code isolated in `discord-bot/`
+- Configuration data in `data/` as text files
+
+## Naming Conventions  
+- **Files**: kebab-case for components, camelCase for utilities
+- **Components**: PascalCase 
+- **Hooks**: camelCase starting with `use`
+- **Constants**: UPPER_SNAKE_CASE
+- **Functions**: camelCase
+
+## Import/Export Style
+- Named exports preferred over default exports
+- External dependencies imported first
+- Relative imports after external
+- Type imports use `import type` when possible
+
+## Comments and Documentation
+- TSDoc comments for public APIs
+- Inline comments for complex logic
+- No unnecessary comments for self-explanatory code
+
+## React Patterns
+- Functional components with hooks
+- Custom hooks for state management logic
+- Props destructuring in function parameters
+- React.StrictMode enabled in development
+
+## Deno/Discord Bot Conventions
+- Import maps in deno.json
+- Permissions explicitly listed in CLI commands
+- Environment variable validation at startup
+- Async/await preferred over Promise chains

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,45 @@
+# Splatoon3 Schedule Notificator - Project Overview
+
+## Purpose
+Discord notification system for Splatoon 3 schedule tracking. Provides web UI for setting notification preferences and Discord bot for automated notifications when specific match conditions are met.
+
+## Architecture
+- **Web UI (React + TypeScript + Vite)**: Frontend for notification settings and Discord integration setup
+- **Discord Bot (Deno + TypeScript)**: Backend bot for handling Discord commands and sending notifications  
+- **Data Pipeline**: GitHub Actions automatically fetches schedule data every 2 hours from Spla3 API
+- **Hosting**: GitHub Pages (WebUI), Deno Deploy (Discord Bot), GitHub Actions (automation)
+
+## Key Features
+- Custom notification conditions (stage, rule, match type combinations)
+- Slack command interface (/watch, /status, /stop, /test, /check)
+- Text file management for event/stage data (external maintenance)
+- Session-based caching for performance optimization
+- Completely free infrastructure (serverless, static hosting)
+
+## Tech Stack
+### Frontend
+- React 18 + TypeScript
+- Vite build tool
+- Tailwind CSS
+- IndexedDB for local storage
+
+### Backend  
+- Deno + TypeScript
+- Discord Webhook API
+- Deno Deploy serverless
+
+### Infrastructure
+- GitHub Pages (WebUI hosting)
+- Vercel (preview environment)
+- GitHub Actions (CI/CD, data fetching)
+- Spla3 API (data source)
+
+## Project Structure
+```
+├── src/                    # React WebUI
+├── discord-bot/           # Deno Discord bot
+├── scripts/               # Data fetching scripts  
+├── data/                  # Text file configuration
+├── .github/workflows/     # CI/CD automation
+└── public/api/            # Generated API data
+```

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,52 @@
+# Suggested Commands
+
+## Development Commands
+
+### WebUI Development
+```bash
+npm run dev          # Start development server (http://localhost:3000)
+npm run build        # Production build
+npm run preview      # Preview production build
+```
+
+### Code Quality
+```bash
+npm run lint         # ESLint check (max-warnings 0)
+npm run lint:fix     # Auto-fix ESLint issues  
+npm run format       # Prettier formatting
+npm run typecheck    # TypeScript type checking
+```
+
+### Discord Bot Development
+```bash
+cd discord-bot
+deno run --allow-net --allow-env --watch main.ts  # Development with watch
+deno run --allow-net --allow-env main.ts          # Production run
+```
+
+### Data Management
+```bash
+npm run fetch-schedule    # Manual schedule data fetch
+cd scripts
+FORCE_UPDATE=true node fetch-schedule.js  # Force schedule update
+```
+
+### System Commands (Linux)
+```bash
+git status            # Git repository status
+ls -la               # List files with details
+find . -name "*.ts"  # Find TypeScript files
+grep -r "pattern"    # Search for patterns
+```
+
+## Task Completion Checklist
+After completing development tasks, run:
+1. `npm run typecheck` - TypeScript validation
+2. `npm run lint` - Code linting
+3. `npm run format` - Code formatting
+4. `npm run build` - Test production build
+
+## Deployment
+- WebUI: Automatic via GitHub Actions on push to main
+- Discord Bot: Automatic via GitHub Actions when discord-bot/ files change
+- Schedule Data: Automatic every 2 hours via GitHub Actions cron

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,65 @@
+# Task Completion Checklist
+
+## Mandatory Steps After Code Changes
+
+### 1. Type Checking (Required)
+```bash
+npm run typecheck
+```
+- Validates TypeScript compilation
+- Must pass without errors before committing
+
+### 2. Code Linting (Required) 
+```bash
+npm run lint
+```
+- ESLint with max-warnings 0 policy
+- Must fix all warnings and errors
+
+### 3. Code Formatting (Required)
+```bash  
+npm run format
+```
+- Prettier formatting for consistent style
+- Automatically formats `src/**/*.{ts,tsx,js,jsx}`
+
+### 4. Build Verification (Required)
+```bash
+npm run build
+```
+- Tests production build process
+- Ensures no build-time errors
+
+## Additional Checks for Specific Changes
+
+### Discord Bot Changes
+```bash
+cd discord-bot
+deno run --allow-net --allow-env main.ts
+```
+- Test Discord bot functionality locally
+- Verify environment variables are accessible
+
+### Schedule Data Changes  
+```bash
+npm run fetch-schedule
+```
+- Test schedule fetching script
+- Verify API integration works
+
+## Pre-Commit Automation
+- **Husky**: Pre-commit hooks configured
+- **lint-staged**: Runs ESLint + Prettier on staged files automatically
+- Manual verification still recommended for complex changes
+
+## Deployment Considerations
+- WebUI: Automatically deploys on push to main via GitHub Actions
+- Discord Bot: Automatically deploys when discord-bot/ files change
+- No manual deployment needed for most cases
+
+## Common Issues to Check
+- No unused imports or variables
+- Environment variables properly handled
+- API endpoints correctly configured for production
+- No hardcoded development URLs
+- TypeScript strict mode compliance


### PR DESCRIPTION
## 修正内容

Discord Bot deployのGitHub Actionsが失敗していた問題を修正しました。

### 問題
- GitHub ActionsでDiscord Bot deployが以下のエラーで失敗：
  ```
  Failed to open entrypoint file at 'discord-bot/webhook.ts': ENOENT
  ```

### 原因
- PR #31でwebhook.tsが削除され、機能がmain.tsに統合された
- しかしGitHub Actionsの設定が更新されていなかった

### 解決方法
- `.github/workflows/deploy.yml`のentrypointを修正：
  - 変更前: `entrypoint: "discord-bot/webhook.ts"`  
  - 変更後: `entrypoint: "discord-bot/main.ts"`

### 追加変更
- `.gitignore`: `.serena/`関連ファイルの設定を追加（開発支援ツール用）
- `.serena/memories/`: プロジェクト情報を追加（onboarding完了）

## 動作確認
- main.tsは完全なWebhook処理機能を持つことを確認済み
- `Deno.serve(handleRequest)`でWebhookサーバーを起動
- Discord署名検証とスラッシュコマンド処理が実装されている

## 関連Issue
Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)