### PR TITLE
feat: Discord Bot deploy workflowに手動実行機能を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
     paths: ['discord-bot/**']
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## 概要

Discord Bot deployのGitHub Actionsワークフローに手動実行機能を追加しました。

## 変更内容

### 追加機能
- `workflow_dispatch`トリガーを追加
- GitHub ActionsのWebUIで「Run workflow」ボタンが表示されるように

### 変更ファイル
- `.github/workflows/deploy.yml`: `workflow_dispatch`を追加

```yaml
on:
  push:
    branches: [main]
    paths: ['discord-bot/**']
  workflow_dispatch:  # 追加
```

## 動作について

### 自動実行（既存）
- mainブランチのdiscord-bot/以下に変更があった時
- **変更なし**: 既存の動作は維持される

### 手動実行（新規）
- GitHub ActionsのWebUIから「Run workflow」で実行
- PRの動作確認に使用可能
- 緊急時の手動deploy実行に使用可能

## 副作用の確認

- ✅ 他のタイミングで余計に動作することはない
- ✅ 既存のpushトリガーに影響なし
- ✅ 手動実行のみの機能追加

## テスト方法

1. このPRをマージ
2. GitHub ActionsのWebUIで「Deploy Discord Bot」ワークフローを確認
3. 「Run workflow」ボタンが表示されることを確認
4. 手動実行してDiscord Bot deployが正常動作することを確認

## 関連Issue
Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)