### PR TITLE
Discord Bot: KVデータ構造の簡素化とパフォーマンス改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
     paths: ['discord-bot/**']
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/discord-bot/README-KV-MIGRATION.md
+++ b/discord-bot/README-KV-MIGRATION.md
@@ -1,0 +1,103 @@
+# KVデータ構造簡素化 - 移行ガイド
+
+## 概要
+
+KVNotificationManagerのデータ構造を簡素化し、保守性とパフォーマンスを向上させました。
+
+## 変更内容
+
+### Before (複雑な構造)
+```
+["notifications","users",userId,guildId] → メタデータ + チャンク情報
+["notifications","chunks",settingId,"0"] → 実際の条件データ (10件ずつ分割)
+["notifications","schedule",settingId] → インデックスデータ
+["user_settings",userId] → レガシーデータ
+```
+
+### After (シンプル構造)
+```
+["notifications",userId,guildId] → {
+  userId, guildId, channelId,
+  conditions: NotificationCondition[],
+  createdAt, updatedAt, settingId, version
+}
+```
+
+## 利点
+
+1. **データ統合**: 1箇所に全データを集約
+2. **複雑性削減**: チャンク分割・復元ロジック削除
+3. **パフォーマンス向上**: インデックス管理不要
+4. **保守性向上**: コードが読みやすく、デバッグが容易
+
+## 移行手順
+
+### 1. テスト実行 (推奨)
+```bash
+# Discord Bot環境で実行
+deno run --allow-all discord-bot/test-kv-manager.ts --test
+```
+
+### 2. データ移行
+```bash
+# 既存データを新形式に移行
+deno run --allow-all discord-bot/migrate-kv-data.ts --migrate
+```
+
+### 3. 動作確認
+- Discord Botが正常に動作することを確認
+- 通知設定が正しく表示されることを確認
+- 新しい通知設定の保存・取得が動作することを確認
+
+### 4. 古いデータ削除 (オプション)
+```bash
+# 古いデータをクリーンアップ
+deno run --allow-all discord-bot/migrate-kv-data.ts --cleanup
+```
+
+## 影響範囲
+
+- `discord-bot/kv-notification-manager.ts`: メインロジック簡素化
+- `discord-bot/notification-checker.ts`: 変更不要（インターフェース互換）
+- KVデータベース: 既存データの移行が必要
+
+## ロールバック方法
+
+万が一問題が発生した場合は、以下の手順でロールバック可能：
+
+1. Git で変更を元に戻す
+2. Deno Deploy で旧バージョンを再デプロイ
+3. 必要に応じて古いKVデータを復旧
+
+## 注意事項
+
+- 移行中は一時的に通知機能が停止する可能性があります
+- 本番環境での実行前に、必ずテスト環境で動作確認してください
+- KVデータのバックアップを取得することをお勧めします
+
+## テスト項目
+
+### 単体テスト
+- [x] 設定の保存・取得
+- [x] 全設定の取得
+- [x] lastNotified更新
+- [x] 設定削除
+
+### 統合テスト
+- [ ] Discord Bot起動確認
+- [ ] 通知設定コマンド動作確認
+- [ ] 定期通知チェック動作確認
+- [ ] 通知送信動作確認
+
+## パフォーマンス比較
+
+| 項目 | 旧構造 | 新構造 | 改善 |
+|------|--------|--------|------|
+| データ取得 | 3回のKVアクセス | 1回のKVアクセス | 67%向上 |
+| 設定保存 | 原子的操作3件 | KV set 1件 | シンプル化 |
+| 全設定取得 | インデックス経由 | 直接スキャン | 高速化 |
+| コード行数 | 292行 | 142行 | 50%削減 |
+
+## 関連Issue
+
+- GitHub Issue #37: Discord Bot: KVデータ構造の簡素化

--- a/discord-bot/migrate-kv-data.ts
+++ b/discord-bot/migrate-kv-data.ts
@@ -1,0 +1,196 @@
+/**
+ * KVデータ移行スクリプト
+ * 旧複雑構造 → 新シンプル構造
+ */
+
+import { NotificationCondition } from './types.ts';
+
+interface OldUserNotificationSettings {
+  userId: string;
+  guildId: string;
+  conditions: NotificationCondition[];
+  createdAt: number;
+  updatedAt: number;
+  settingId: string;
+  version: string;
+  channelId: string;
+  chunkCount?: number;
+  totalConditions?: number;
+}
+
+interface NewUserNotificationSettings {
+  userId: string;
+  guildId: string;
+  channelId: string;
+  conditions: NotificationCondition[];
+  createdAt: number;
+  updatedAt: number;
+  settingId: string;
+  version: string;
+}
+
+async function migrateKVData() {
+  const kv = await Deno.openKv();
+  
+  try {
+    console.log('🔄 KVデータ移行開始...');
+    
+    const migratedCount = { users: 0, legacy: 0, chunks: 0, schedules: 0 };
+    
+    // 1. 旧user_settingsデータを移行
+    console.log('📦 旧user_settingsデータを検索中...');
+    const legacyIter = kv.list({ prefix: ['user_settings'] });
+    
+    for await (const { key, value } of legacyIter) {
+      const settings = value as any;
+      console.log(`📝 移行中: ${settings.userId}/${settings.channelId}`);
+      
+      // 新形式で保存（guildIdがない場合はuserIdを使用）
+      const guildId = settings.guildId || settings.userId;
+      const newSettings: NewUserNotificationSettings = {
+        userId: settings.userId,
+        guildId,
+        channelId: settings.channelId,
+        conditions: settings.conditions || [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        settingId: crypto.randomUUID(),
+        version: '2.0'
+      };
+      
+      await kv.set(['notifications', settings.userId, guildId], newSettings);
+      migratedCount.legacy++;
+    }
+    
+    // 2. 旧notifications/usersデータを移行
+    console.log('📦 旧notifications/usersデータを検索中...');
+    const usersIter = kv.list({ prefix: ['notifications', 'users'] });
+    
+    for await (const { key, value } of usersIter) {
+      const [, , userId, guildId] = key as string[];
+      const oldSettings = value as OldUserNotificationSettings;
+      
+      console.log(`📝 移行中: ${userId}/${guildId}`);
+      
+      let allConditions: NotificationCondition[] = [];
+      
+      // チャンクからデータを復元
+      if (oldSettings.chunkCount && oldSettings.chunkCount > 0) {
+        for (let i = 0; i < oldSettings.chunkCount; i++) {
+          try {
+            const chunkResult = await kv.get(['notifications', 'chunks', oldSettings.settingId, i.toString()]);
+            if (chunkResult.value) {
+              allConditions.push(...(chunkResult.value as NotificationCondition[]));
+            }
+          } catch (error) {
+            console.warn(`⚠️ チャンク ${i} の読み込みに失敗: ${error}`);
+          }
+        }
+      } else {
+        allConditions = oldSettings.conditions || [];
+      }
+      
+      const newSettings: NewUserNotificationSettings = {
+        userId: oldSettings.userId,
+        guildId: oldSettings.guildId,
+        channelId: oldSettings.channelId,
+        conditions: allConditions,
+        createdAt: oldSettings.createdAt,
+        updatedAt: Date.now(),
+        settingId: crypto.randomUUID(),
+        version: '2.0'
+      };
+      
+      await kv.set(['notifications', userId, guildId], newSettings);
+      migratedCount.users++;
+    }
+    
+    console.log('✅ 移行完了');
+    console.log(`📊 移行結果:`);
+    console.log(`   - 旧user_settingsユーザー: ${migratedCount.legacy}件`);
+    console.log(`   - 旧notifications/usersユーザー: ${migratedCount.users}件`);
+    
+    // 3. 移行確認
+    console.log('🔍 移行結果を確認中...');
+    const newIter = kv.list({ prefix: ['notifications'] });
+    let newCount = 0;
+    
+    for await (const { key, value } of newIter) {
+      const [prefix, userId, guildId] = key as string[];
+      if (prefix === 'notifications' && userId && guildId) {
+        const settings = value as NewUserNotificationSettings;
+        console.log(`✅ 新形式: ${userId}/${guildId} (${settings.conditions.length} conditions)`);
+        newCount++;
+      }
+    }
+    
+    console.log(`📈 新形式データ総数: ${newCount}件`);
+    
+    console.log('🧹 古いデータをクリーンアップしますか？ (手動で実行してください)');
+    console.log('   - 旧user_settingsデータ');
+    console.log('   - 旧notifications/users, chunks, scheduleデータ');
+    
+  } catch (error) {
+    console.error('❌ 移行エラー:', error);
+    throw error;
+  } finally {
+    kv.close();
+  }
+}
+
+async function cleanupOldData() {
+  const kv = await Deno.openKv();
+  
+  try {
+    console.log('🧹 古いデータのクリーンアップ開始...');
+    
+    // user_settingsを削除
+    const legacyIter = kv.list({ prefix: ['user_settings'] });
+    for await (const { key } of legacyIter) {
+      await kv.delete(key);
+      console.log(`🗑️ 削除: ${key.join('/')}`);
+    }
+    
+    // 旧notifications構造を削除
+    const oldNotificationsIter = kv.list({ prefix: ['notifications', 'users'] });
+    for await (const { key } of oldNotificationsIter) {
+      await kv.delete(key);
+      console.log(`🗑️ 削除: ${key.join('/')}`);
+    }
+    
+    const chunksIter = kv.list({ prefix: ['notifications', 'chunks'] });
+    for await (const { key } of chunksIter) {
+      await kv.delete(key);
+      console.log(`🗑️ 削除: ${key.join('/')}`);
+    }
+    
+    const scheduleIter = kv.list({ prefix: ['notifications', 'schedule'] });
+    for await (const { key } of scheduleIter) {
+      await kv.delete(key);
+      console.log(`🗑️ 削除: ${key.join('/')}`);
+    }
+    
+    console.log('✅ クリーンアップ完了');
+    
+  } catch (error) {
+    console.error('❌ クリーンアップエラー:', error);
+    throw error;
+  } finally {
+    kv.close();
+  }
+}
+
+// 実行
+if (Deno.args.length > 0) {
+  const args = Deno.args;
+  
+  if (args.includes('--migrate')) {
+    await migrateKVData();
+  } else if (args.includes('--cleanup')) {
+    await cleanupOldData();
+  } else {
+    console.log('使用方法:');
+    console.log('  deno run --allow-all migrate-kv-data.ts --migrate   # データ移行');
+    console.log('  deno run --allow-all migrate-kv-data.ts --cleanup   # 古いデータ削除');
+  }
+}


### PR DESCRIPTION
## 概要

Discord BotのKVNotificationManagerを大幅に簡素化し、パフォーマンスと保守性を向上させました。

## 🎯 解決する問題

現在のKVデータ構造は過度に複雑で、以下の問題がありました：
- データが3箇所に分散（users, chunks, schedule）
- 不要なチャンク分割システム
- インデックス管理のオーバーヘッド
- 保守困難な複雑なロジック

## ✨ 主な改善点

### 1. データ構造の統合
**Before (複雑):**
```
["notifications","users",userId,guildId] → メタデータ
["notifications","chunks",settingId,"0"] → 実データ (10件ずつ分割)
["notifications","schedule",settingId] → インデックス
```

**After (シンプル):**
```
["notifications",userId,guildId] → {
  userId, guildId, channelId, conditions[],
  createdAt, updatedAt, settingId, version
}
```

### 2. パフォーマンス向上
| 項目 | 改善前 | 改善後 | 向上率 |
|------|--------|--------|--------|
| データ取得 | 3回KVアクセス | 1回KVアクセス | 67%向上 |
| 設定保存 | 原子的操作3件 | KV set 1件 | シンプル化 |
| 全設定取得 | インデックス経由 | 直接スキャン | 高速化 |
| コード行数 | 292行 | 142行 | 50%削減 |

### 3. 保守性改善
- チャンク分割・復元ロジック削除
- データ整合性リスク削減
- デバッグとテストが容易

## 🧪 テスト結果

✅ モックデータによるロジックテスト完了
- 設定保存・取得: 正常
- 複数ユーザー対応: 正常
- lastNotified更新: 正常
- 設定削除: 正常
- データ整合性: 問題なし

## 📁 変更ファイル

### 修正
- `discord-bot/kv-notification-manager.ts`: メインロジック簡素化

### 新規追加
- `discord-bot/migrate-kv-data.ts`: 既存データ移行スクリプト
- `discord-bot/README-KV-MIGRATION.md`: 移行ガイド

## 🚀 デプロイ手順

1. **本PR マージ後**
2. **データ移行実行**:
   ```bash
   deno run --allow-all discord-bot/migrate-kv-data.ts --migrate
   ```
3. **動作確認**:
   - Discord Botの起動確認
   - `/status` コマンドでの設定表示確認
   - `/watch` コマンドでの新規設定保存確認
4. **古いデータクリーンアップ** (オプション):
   ```bash
   deno run --allow-all discord-bot/migrate-kv-data.ts --cleanup
   ```

## ⚠️ 注意事項

- 移行中は一時的に通知機能が停止する可能性があります
- 本番環境実行前に必ずテスト環境で動作確認してください
- 既存データは移行スクリプトで自動変換されます

## 🔄 ロールバック方法

万が一問題が発生した場合：
1. Git で変更を元に戻す
2. Deno Deploy で旧バージョンを再デプロイ  
3. 必要に応じて古いKVデータを復旧

## 関連Issue

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)