### PR TITLE
fix: GitHub CLI認証エラーを解決してghコマンドを正常動作させる

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,8 @@ jobs:
           fetch-depth: 1
 
       - name: Setup GitHub CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # GitHub CLIがプリインストールされているかを確認
           if ! command -v gh &> /dev/null; then
@@ -55,10 +57,20 @@ jobs:
             echo "✅ GitHub CLIは既にインストール済みです"
             gh --version
           fi
+          
+          # GitHub CLI認証確認
+          echo "🔐 GitHub CLI認証状況を確認中..."
+          if gh auth status; then
+            echo "✅ GitHub CLI認証成功"
+          else
+            echo "❌ GitHub CLI認証に問題があります"
+          fi
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -76,7 +88,18 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Allow Claude to run lint and formatting commands (merged with main)
-          allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run dev),Bash(npm run preview),Bash(npm run fetch-schedule),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format),Bash(npm run typecheck),Bash(git *),Bash(gh *)"
+          allowed_tools: |
+            Bash(npm install)
+            Bash(npm run build)
+            Bash(npm run dev)
+            Bash(npm run preview)
+            Bash(npm run fetch-schedule)
+            Bash(npm run lint)
+            Bash(npm run lint:fix)
+            Bash(npm run format)
+            Bash(npm run typecheck)
+            Bash(git *)
+            Bash(gh *)
           
           # Custom instructions for Claude to customize its behavior for your project
           custom_instructions: |


### PR DESCRIPTION
## 概要
Issue #42で報告されたGitHub Actions内でのghコマンド認証エラーを修正します。

## 問題
段階的開発プロセスでラベル管理を行う際、ClaudeがGitHub CLI (gh)コマンドを実行すると認証エラーが発生していました。

## 根本原因
GitHub Actions内でClaude Code Actionがghコマンドを実行する際、GITHUB_TOKENが環境変数として渡されていなかったため、GitHub APIアクセスで認証に失敗。

## 解決方法

### 1. GitHub CLI認証設定の追加
- Setup GitHub CLIステップにGITHUB_TOKEN環境変数を追加
- Claude Code ActionにもGITHUB_TOKEN環境変数を渡す

### 2. 認証確認機能の追加
- GitHub CLI認証状況の確認処理を追加
- 認証失敗時のデバッグ情報を改善

### 3. 設定ファイルの可読性向上
- allowed_toolsをマルチラインフォーマットに変更
- YAML構文エラーの回避

## 影響範囲
- `.github/workflows/claude.yml`
- 段階的開発プロセスのラベル管理機能

## テスト方法
1. Issue #41で@claudeメンションしてラベル管理が動作することを確認
2. 段階的開発プロセスの各フェーズでラベル設定が正常に動作することを確認

## 関連Issue
Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)