### PR TITLE
feat: Discord Botでイベントマッチの通知に対応

### DIFF
--- a/discord-bot/main.ts
+++ b/discord-bot/main.ts
@@ -13,6 +13,11 @@ import {
   shouldCheckForNotification,
   checkEventNotificationConditions,
 } from './notifications.ts';
+import {
+  sendRegularMatchNotification,
+  sendEventMatchNotification,
+  NOTIFICATION_LIMITS,
+} from './notification-utils.ts';
 import { getAllEventMatches } from './schedule.ts';
 
 import { NotificationChecker } from './notification-checker.ts';
@@ -752,7 +757,7 @@ async function manualNotificationCheck(settings: any, channelId: string) {
 
         // ステージ条件チェック
         if (condition.stages && condition.stages.length > 0) {
-          const matchStageIds = match.stages.map((stage: Stage) => stage.id);
+          const matchStageIds = match.stages.map((stage) => stage.id);
           const hasMatchingStage = condition.stages.some((stageId) =>
             matchStageIds.includes(stageId)
           );
@@ -765,8 +770,14 @@ async function manualNotificationCheck(settings: any, channelId: string) {
       });
 
       // 通常マッチの通知（最初の3件まで、スパム防止）
-      for (const match of matchingMatches.slice(0, 3)) {
-        const success = await sendMatchNotification(settings, condition, match);
+      for (const match of matchingMatches.slice(0, NOTIFICATION_LIMITS.MAX_NOTIFICATIONS_PER_CONDITION)) {
+        const success = await sendRegularMatchNotification(
+          settings.channelId,
+          condition,
+          match,
+          DISCORD_TOKEN,
+          true // isManualCheck
+        );
         if (success) {
           notificationsSent++;
         }
@@ -787,11 +798,13 @@ async function manualNotificationCheck(settings: any, channelId: string) {
       );
 
       // イベントマッチの通知（最初の3件まで、スパム防止）
-      for (const eventMatch of matchingEventMatches.slice(0, 3)) {
+      for (const eventMatch of matchingEventMatches.slice(0, NOTIFICATION_LIMITS.MAX_NOTIFICATIONS_PER_CONDITION)) {
         const success = await sendEventMatchNotification(
-          settings,
+          settings.channelId,
           condition,
-          eventMatch
+          eventMatch,
+          DISCORD_TOKEN,
+          true // isManualCheck
         );
         if (success) {
           notificationsSent++;
@@ -821,170 +834,7 @@ async function manualNotificationCheck(settings: any, channelId: string) {
   }
 }
 
-// マッチ通知送信（手動チェック用）
-async function sendMatchNotification(
-  userSettings: any,
-  condition: NotificationCondition,
-  match: ScheduleMatch
-): Promise<boolean> {
-  try {
-    const stages = match.stages.map((stage: Stage) => stage.name).join(', ');
-    const startTime = new Date(match.start_time).toLocaleString('ja-JP', {
-      timeZone: 'Asia/Tokyo',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
 
-    const embed = {
-      title: '🦑 スプラトゥーン3 通知',
-      description: `**${condition.name}** の条件に合致しました！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`,
-      fields: [
-        {
-          name: 'ルール',
-          value: match.rule.name,
-          inline: true,
-        },
-        {
-          name: 'マッチタイプ',
-          value: match.match_type,
-          inline: true,
-        },
-        {
-          name: 'ステージ',
-          value: stages,
-          inline: false,
-        },
-        {
-          name: '開始時刻',
-          value: startTime,
-          inline: false,
-        },
-      ],
-      color: 0x00ff88,
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Splatoon3 Schedule Bot',
-      },
-    };
-
-    const response = await fetch(
-      `https://discord.com/api/v10/channels/${userSettings.channelId}/messages`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bot ${DISCORD_TOKEN}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          embeds: [embed],
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error(`❌ 通知送信失敗:`, error);
-      return false;
-    }
-
-    console.log(`✅ 通知送信成功: "${condition.name}"`);
-    return true;
-  } catch (error) {
-    console.error(`❌ 通知送信エラー:`, error);
-    return false;
-  }
-}
-
-// イベントマッチ通知送信（手動チェック用）
-async function sendEventMatchNotification(
-  userSettings: any,
-  condition: NotificationCondition,
-  eventMatch: EventMatch
-): Promise<boolean> {
-  try {
-    const stages = eventMatch.stages
-      .map((stage: Stage) => stage.name)
-      .join(', ');
-    const startTime = new Date(eventMatch.start_time).toLocaleString('ja-JP', {
-      timeZone: 'Asia/Tokyo',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-
-    const embed = {
-      title: '🎪 スプラトゥーン3 イベントマッチ通知',
-      description: `**${condition.name}** の条件に合致しました！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`,
-      fields: [
-        {
-          name: 'イベント名',
-          value: eventMatch.event.name,
-          inline: true,
-        },
-        {
-          name: 'ルール',
-          value: eventMatch.rule.name,
-          inline: true,
-        },
-        {
-          name: 'ステージ',
-          value: stages,
-          inline: false,
-        },
-        {
-          name: '開始時刻',
-          value: startTime,
-          inline: false,
-        },
-        {
-          name: '説明',
-          value: eventMatch.event.desc || 'なし',
-          inline: false,
-        },
-      ],
-      color: 0xff6600, // オレンジ色でイベントマッチを識別
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Splatoon3 Schedule Bot - Event Match',
-      },
-    };
-
-    const response = await fetch(
-      `https://discord.com/api/v10/channels/${userSettings.channelId}/messages`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bot ${DISCORD_TOKEN}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          embeds: [embed],
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error(`❌ イベントマッチ通知送信失敗:`, error);
-      return false;
-    }
-
-    console.log(
-      `✅ イベントマッチ通知送信成功: "${condition.name}" - ${eventMatch.event.name}`
-    );
-    return true;
-  } catch (error) {
-    console.error(`❌ イベントマッチ通知送信エラー:`, error);
-    return false;
-  }
-}
 
 // シンプルメッセージ送信
 async function sendSimpleMessage(

--- a/discord-bot/notification-utils.ts
+++ b/discord-bot/notification-utils.ts
@@ -1,0 +1,193 @@
+import { ScheduleMatch, EventMatch, NotificationCondition, Stage, Embed } from './types.ts';
+
+// 通知送信の制限設定
+export const NOTIFICATION_LIMITS = {
+  MAX_NOTIFICATIONS_PER_CONDITION: 3,
+} as const;
+
+// Embedの色設定
+export const EMBED_COLORS = {
+  REGULAR_MATCH: 0x00ff88,
+  EVENT_MATCH: 0xff6600,
+  TEST: 0x00ff88,
+} as const;
+
+/**
+ * 通常マッチ用のEmbedを作成
+ */
+export function createRegularMatchEmbed(
+  condition: NotificationCondition,
+  match: ScheduleMatch,
+  isManualCheck = false
+): Embed {
+  const stages = match.stages.map((stage: Stage) => stage.name).join(', ');
+  const startTime = formatDateTime(match.start_time);
+
+  const description = isManualCheck
+    ? `**${condition.name}** の条件に合致しました！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`
+    : `**${condition.name}** の条件に合致しました！\n${condition.notifyMinutesBefore}分前です！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`;
+
+  return {
+    title: '🦑 スプラトゥーン3 通知',
+    description,
+    fields: [
+      {
+        name: 'ルール',
+        value: match.rule.name,
+        inline: true,
+      },
+      {
+        name: 'マッチタイプ',
+        value: match.match_type,
+        inline: true,
+      },
+      {
+        name: 'ステージ',
+        value: stages,
+        inline: false,
+      },
+      {
+        name: '開始時刻',
+        value: startTime,
+        inline: false,
+      },
+    ],
+    color: EMBED_COLORS.REGULAR_MATCH,
+    timestamp: new Date().toISOString(),
+    footer: {
+      text: 'Splatoon3 Schedule Bot',
+    },
+  };
+}
+
+/**
+ * イベントマッチ用のEmbedを作成
+ */
+export function createEventMatchEmbed(
+  condition: NotificationCondition,
+  eventMatch: EventMatch,
+  isManualCheck = false
+): Embed {
+  const stages = eventMatch.stages.map((stage: Stage) => stage.name).join(', ');
+  const startTime = formatDateTime(eventMatch.start_time);
+
+  const description = isManualCheck
+    ? `**${condition.name}** の条件に合致しました！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`
+    : `**${condition.name}** の条件に合致しました！\n${condition.notifyMinutesBefore}分前です！\n\n詳細なスケジュール: https://qnaiv.github.io/splatoon3-schedule-notificator/`;
+
+  return {
+    title: '🎪 スプラトゥーン3 イベントマッチ通知',
+    description,
+    fields: [
+      {
+        name: 'イベント名',
+        value: eventMatch.event.name,
+        inline: true,
+      },
+      {
+        name: 'ルール',
+        value: eventMatch.rule.name,
+        inline: true,
+      },
+      {
+        name: 'ステージ',
+        value: stages,
+        inline: false,
+      },
+      {
+        name: '開始時刻',
+        value: startTime,
+        inline: false,
+      },
+      {
+        name: '説明',
+        value: eventMatch.event.desc || 'なし',
+        inline: false,
+      },
+    ],
+    color: EMBED_COLORS.EVENT_MATCH,
+    timestamp: new Date().toISOString(),
+    footer: {
+      text: 'Splatoon3 Schedule Bot - Event Match',
+    },
+  };
+}
+
+/**
+ * Discord APIにメッセージを送信する共通関数
+ */
+export async function sendDiscordMessage(
+  channelId: string,
+  embed: Embed,
+  discordToken: string
+): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `https://discord.com/api/v10/channels/${channelId}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bot ${discordToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          embeds: [embed],
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error('❌ Discord通知送信失敗:', error);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('❌ Discord通知送信エラー:', error);
+    return false;
+  }
+}
+
+/**
+ * 日時をフォーマットする共通関数
+ */
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * 通常マッチの通知を送信
+ */
+export async function sendRegularMatchNotification(
+  channelId: string,
+  condition: NotificationCondition,
+  match: ScheduleMatch,
+  discordToken: string,
+  isManualCheck = false
+): Promise<boolean> {
+  const embed = createRegularMatchEmbed(condition, match, isManualCheck);
+  return await sendDiscordMessage(channelId, embed, discordToken);
+}
+
+/**
+ * イベントマッチの通知を送信
+ */
+export async function sendEventMatchNotification(
+  channelId: string,
+  condition: NotificationCondition,
+  eventMatch: EventMatch,
+  discordToken: string,
+  isManualCheck = false
+): Promise<boolean> {
+  const embed = createEventMatchEmbed(condition, eventMatch, isManualCheck);
+  return await sendDiscordMessage(channelId, embed, discordToken);
+}


### PR DESCRIPTION
## 📋 概要

Discord Botでイベントマッチの通知が送信されない問題を修正しました。

## 🔧 変更内容

- 定期通知チェッカーでイベントマッチ処理を追加
- 手動チェック時のイベントマッチ対応を追加
- イベントマッチ専用の通知フォーマット実装
- 既存の通常マッチ通知機能は保持

## 🧪 テスト計画

- [ ] ジェットパック祭りの通知設定で動作確認
- [ ] `/check`コマンドでイベントマッチが表示されるか確認
- [ ] 通常マッチの通知が引き続き正常動作するか確認

Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)