### PR TITLE
feat: イベントマッチタブから通知条件を作成できる機能を実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,9 @@ import NotificationDialog from './components/NotificationDialog';
 import { useSchedule } from './hooks/useSchedule';
 import { useEventMatches } from './hooks/useEventMatches';
 import { useSettings } from './hooks/useSettings';
-import { ScheduleMatch, NotificationCondition } from './types';
+import { ScheduleMatch, EventMatch, NotificationCondition } from './types';
 import { scheduleToCondition } from './utils/scheduleToCondition';
+import { eventMatchToCondition } from './utils/eventMatchToCondition';
 
 const App: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<
@@ -17,6 +18,8 @@ const App: React.FC = () => {
   const [showNotificationDialog, setShowNotificationDialog] = useState(false);
   const [selectedSchedule, setSelectedSchedule] =
     useState<ScheduleMatch | null>(null);
+  const [selectedEventMatch, setSelectedEventMatch] =
+    useState<EventMatch | null>(null);
   const {
     currentMatches,
     upcomingMatches,
@@ -56,6 +59,13 @@ const App: React.FC = () => {
 
   const handleScheduleCardClick = (match: ScheduleMatch) => {
     setSelectedSchedule(match);
+    setSelectedEventMatch(null);
+    setShowNotificationDialog(true);
+  };
+
+  const handleEventCardClick = (match: EventMatch) => {
+    setSelectedEventMatch(match);
+    setSelectedSchedule(null);
     setShowNotificationDialog(true);
   };
 
@@ -66,6 +76,7 @@ const App: React.FC = () => {
       await addNotificationCondition(conditionData);
       setShowNotificationDialog(false);
       setSelectedSchedule(null);
+      setSelectedEventMatch(null);
       // 成功した場合は設定タブに移動
       setCurrentTab('settings');
     } catch (err) {
@@ -77,6 +88,7 @@ const App: React.FC = () => {
   const handleNotificationCancel = () => {
     setShowNotificationDialog(false);
     setSelectedSchedule(null);
+    setSelectedEventMatch(null);
   };
 
   return (
@@ -207,6 +219,7 @@ const App: React.FC = () => {
             error={eventError}
             formatTime={formatTime}
             formatDate={formatDate}
+            onEventCardClick={handleEventCardClick}
           />
         ) : (
           <NotificationSettings />
@@ -217,7 +230,11 @@ const App: React.FC = () => {
       <NotificationDialog
         isOpen={showNotificationDialog}
         initialCondition={
-          selectedSchedule ? scheduleToCondition(selectedSchedule) : undefined
+          selectedSchedule
+            ? scheduleToCondition(selectedSchedule)
+            : selectedEventMatch
+              ? eventMatchToCondition(selectedEventMatch)
+              : undefined
         }
         allStages={allStages}
         onSave={handleNotificationSave}

--- a/src/components/EventMatchesView.tsx
+++ b/src/components/EventMatchesView.tsx
@@ -9,6 +9,7 @@ interface EventMatchesViewProps {
   error: string | null;
   formatTime: (dateString: string) => string;
   formatDate: (dateString: string) => string;
+  onEventCardClick?: (match: EventMatch) => void;
 }
 
 const EventMatchesView: React.FC<EventMatchesViewProps> = ({
@@ -17,27 +18,29 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
   loading,
   error,
   formatTime,
-  formatDate
+  formatDate,
+  onEventCardClick,
 }) => {
-
-
   // イベントをグルーピング
   const groupEventsByType = (events: EventMatch[]) => {
     const groups: { [key: string]: EventMatch[] } = {};
-    
-    events.forEach(event => {
+
+    events.forEach((event) => {
       const eventId = event.event?.id || 'unknown';
       if (!groups[eventId]) {
         groups[eventId] = [];
       }
       groups[eventId].push(event);
     });
-    
+
     // 各グループ内で時間順にソート
-    Object.values(groups).forEach(group => {
-      group.sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
+    Object.values(groups).forEach((group) => {
+      group.sort(
+        (a, b) =>
+          new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+      );
     });
-    
+
     return groups;
   };
 
@@ -47,12 +50,12 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
     if (events.length === 1) {
       return `${formatDate(events[0].start_time)} ${formatTime(events[0].start_time)} ～ ${formatTime(events[0].end_time)}`;
     }
-    
+
     const firstEvent = events[0];
     const lastEvent = events[events.length - 1];
     const firstDate = formatDate(firstEvent.start_time);
     const lastDate = formatDate(lastEvent.end_time);
-    
+
     if (firstDate === lastDate) {
       return `${firstDate} ${formatTime(firstEvent.start_time)} ～ ${formatTime(lastEvent.end_time)}`;
     } else {
@@ -63,7 +66,7 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
   // 開催時間帯を日付別にグループ化
   const groupEventsByDate = (events: EventMatch[]) => {
     const dateGroups: { [date: string]: EventMatch[] } = {};
-    events.forEach(event => {
+    events.forEach((event) => {
       const date = formatDate(event.start_time);
       if (!dateGroups[date]) {
         dateGroups[date] = [];
@@ -76,40 +79,53 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
   const getEventTypeColor = (eventName: string | undefined) => {
     if (!eventName) {
       return {
-        color: 'bg-gradient-to-r from-blue-500/20 to-teal-500/20 text-blue-800 border-blue-500/30',
-        bgColor: 'bg-gradient-to-br from-blue-50/80 via-teal-50/80 to-blue-50/80',
+        color:
+          'bg-gradient-to-r from-blue-500/20 to-teal-500/20 text-blue-800 border-blue-500/30',
+        bgColor:
+          'bg-gradient-to-br from-blue-50/80 via-teal-50/80 to-blue-50/80',
         borderColor: 'border-blue-200/50',
-        shadowColor: 'shadow-blue/10'
+        shadowColor: 'shadow-blue/10',
       };
     }
-    
+
     if (eventName.includes('ツキイチ') || eventName.includes('Monthly')) {
       return {
-        color: 'bg-gradient-to-r from-purple-500/20 to-pink-500/20 text-purple-800 border-purple-500/30',
-        bgColor: 'bg-gradient-to-br from-purple-50/80 via-pink-50/80 to-purple-50/80',
+        color:
+          'bg-gradient-to-r from-purple-500/20 to-pink-500/20 text-purple-800 border-purple-500/30',
+        bgColor:
+          'bg-gradient-to-br from-purple-50/80 via-pink-50/80 to-purple-50/80',
         borderColor: 'border-purple-200/50',
-        shadowColor: 'shadow-purple/10'
+        shadowColor: 'shadow-purple/10',
       };
-    } else if (eventName.includes('ビッグラン') || eventName.includes('Big Run')) {
+    } else if (
+      eventName.includes('ビッグラン') ||
+      eventName.includes('Big Run')
+    ) {
       return {
-        color: 'bg-gradient-to-r from-orange-500/20 to-red-500/20 text-orange-800 border-orange-500/30',
-        bgColor: 'bg-gradient-to-br from-orange-50/80 via-red-50/80 to-orange-50/80',
+        color:
+          'bg-gradient-to-r from-orange-500/20 to-red-500/20 text-orange-800 border-orange-500/30',
+        bgColor:
+          'bg-gradient-to-br from-orange-50/80 via-red-50/80 to-orange-50/80',
         borderColor: 'border-orange-200/50',
-        shadowColor: 'shadow-orange/10'
+        shadowColor: 'shadow-orange/10',
       };
     } else if (eventName.includes('霧') || eventName.includes('Fog')) {
       return {
-        color: 'bg-gradient-to-r from-gray-500/20 to-slate-500/20 text-gray-800 border-gray-500/30',
-        bgColor: 'bg-gradient-to-br from-gray-50/80 via-slate-50/80 to-gray-50/80',
+        color:
+          'bg-gradient-to-r from-gray-500/20 to-slate-500/20 text-gray-800 border-gray-500/30',
+        bgColor:
+          'bg-gradient-to-br from-gray-50/80 via-slate-50/80 to-gray-50/80',
         borderColor: 'border-gray-200/50',
-        shadowColor: 'shadow-gray/10'
+        shadowColor: 'shadow-gray/10',
       };
     } else {
       return {
-        color: 'bg-gradient-to-r from-blue-500/20 to-teal-500/20 text-blue-800 border-blue-500/30',
-        bgColor: 'bg-gradient-to-br from-blue-50/80 via-teal-50/80 to-blue-50/80',
+        color:
+          'bg-gradient-to-r from-blue-500/20 to-teal-500/20 text-blue-800 border-blue-500/30',
+        bgColor:
+          'bg-gradient-to-br from-blue-50/80 via-teal-50/80 to-blue-50/80',
         borderColor: 'border-blue-200/50',
-        shadowColor: 'shadow-blue/10'
+        shadowColor: 'shadow-blue/10',
       };
     }
   };
@@ -146,130 +162,178 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
 
         {currentEvents.length === 0 ? (
           <div className="bg-white/40 backdrop-blur-sm rounded-xl p-6 text-center border border-white/30 shadow-lg">
-            <p className="text-gray-600">現在開催中のイベントマッチはありません</p>
+            <p className="text-gray-600">
+              現在開催中のイベントマッチはありません
+            </p>
           </div>
         ) : (
           <div className="space-y-4">
-            {Object.entries(groupEventsByType(currentEvents)).map(([, events], groupIndex) => {
-              const event = events[0]; // 代表のイベント情報を使用
-              const eventTypeInfo = getEventTypeColor(event.event?.name);
-              const stageNames = event.stages?.map(stage => stage?.name || '不明').join(' / ') || '不明';
-              const stageImages = event.stages?.filter(stage => stage?.image).map(stage => stage.image) || [];
-              
-              const backgroundStyle = stageImages.length >= 2 ? {} : stageImages.length === 1 ? {
-                backgroundImage: `url('${stageImages[0]}')`,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
-                backgroundRepeat: 'no-repeat'
-              } : {};
+            {Object.entries(groupEventsByType(currentEvents)).map(
+              ([, events], groupIndex) => {
+                const event = events[0]; // 代表のイベント情報を使用
+                const eventTypeInfo = getEventTypeColor(event.event?.name);
+                const stageNames =
+                  event.stages
+                    ?.map((stage) => stage?.name || '不明')
+                    .join(' / ') || '不明';
+                const stageImages =
+                  event.stages
+                    ?.filter((stage) => stage?.image)
+                    .map((stage) => stage.image) || [];
 
-              return (
-                <div 
-                  key={`current-event-group-${groupIndex}`} 
-                  className={`rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 relative overflow-hidden ${stageImages.length > 0 ? '' : eventTypeInfo.bgColor}`}
-                  style={backgroundStyle}
-                >
-                  {/* 2つのステージの場合の背景 */}
-                  {stageImages.length >= 2 && (
-                    <>
-                      <div 
-                        className="absolute inset-0 rounded-xl opacity-80"
-                        style={{
+                const backgroundStyle =
+                  stageImages.length >= 2
+                    ? {}
+                    : stageImages.length === 1
+                      ? {
                           backgroundImage: `url('${stageImages[0]}')`,
                           backgroundSize: 'cover',
                           backgroundPosition: 'center',
                           backgroundRepeat: 'no-repeat',
-                          clipPath: 'polygon(0 0, 50% 0, 50% 100%, 0 100%)'
-                        }}
-                      />
-                      <div 
-                        className="absolute inset-0 rounded-xl opacity-80"
-                        style={{
-                          backgroundImage: `url('${stageImages[1]}')`,
-                          backgroundSize: 'cover',
-                          backgroundPosition: 'center',
-                          backgroundRepeat: 'no-repeat',
-                          clipPath: 'polygon(50% 0, 100% 0, 100% 100%, 50% 100%)'
-                        }}
-                      />
-                    </>
-                  )}
-                  
-                  {/* 可読性向上のためのオーバーレイ */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/60 to-white/50 backdrop-blur-xs rounded-xl"></div>
-                  
-                  {/* コンテンツ */}
-                  <div className="relative z-10">
-                    <div className="flex items-start justify-between mb-4">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-3">
-                          <span className={`px-4 py-2 rounded-full text-sm font-bold border-2 ${eventTypeInfo.color} bg-white shadow-xl`}>
-                            🎪 イベントマッチ
-                          </span>
-                          <span className="bg-gradient-to-r from-green-400 to-emerald-500 text-white text-sm px-3 py-1 rounded-full shadow-lg animate-pulse font-bold">
-                            開催中
-                          </span>
-                        </div>
-                        
-                        <h3 className="text-xl font-bold text-gray-900 mb-2">{event.event?.name || 'イベントマッチ'}</h3>
-                        {event.event?.desc && (
-                          <p className="text-sm text-gray-700 mb-3 leading-relaxed">{event.event.desc}</p>
-                        )}
-                        
-                        <div className="space-y-3">
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">開催期間:</span>
-                            <span className="text-gray-700 font-bold">
-                              {formatEventPeriod(events)}
+                        }
+                      : {};
+
+                return (
+                  <div
+                    key={`current-event-group-${groupIndex}`}
+                    className={`rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 relative overflow-hidden cursor-pointer ${stageImages.length > 0 ? '' : eventTypeInfo.bgColor}`}
+                    style={backgroundStyle}
+                    onClick={() => onEventCardClick?.(event)}
+                  >
+                    {/* 2つのステージの場合の背景 */}
+                    {stageImages.length >= 2 && (
+                      <>
+                        <div
+                          className="absolute inset-0 rounded-xl opacity-80"
+                          style={{
+                            backgroundImage: `url('${stageImages[0]}')`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                            clipPath: 'polygon(0 0, 50% 0, 50% 100%, 0 100%)',
+                          }}
+                        />
+                        <div
+                          className="absolute inset-0 rounded-xl opacity-80"
+                          style={{
+                            backgroundImage: `url('${stageImages[1]}')`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                            clipPath:
+                              'polygon(50% 0, 100% 0, 100% 100%, 50% 100%)',
+                          }}
+                        />
+                      </>
+                    )}
+
+                    {/* 可読性向上のためのオーバーレイ */}
+                    <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/60 to-white/50 backdrop-blur-xs rounded-xl"></div>
+
+                    {/* コンテンツ */}
+                    <div className="relative z-10">
+                      <div className="flex items-start justify-between mb-4">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-3 mb-3">
+                            <span
+                              className={`px-4 py-2 rounded-full text-sm font-bold border-2 ${eventTypeInfo.color} bg-white shadow-xl`}
+                            >
+                              🎪 イベントマッチ
+                            </span>
+                            <span className="bg-gradient-to-r from-green-400 to-emerald-500 text-white text-sm px-3 py-1 rounded-full shadow-lg animate-pulse font-bold">
+                              開催中
                             </span>
                           </div>
-                          <div className="text-sm">
-                            <span className="font-semibold text-gray-800 block mb-2">開催時間帯:</span>
-                            <div className="space-y-2">
-                              {Object.entries(groupEventsByDate(events)).map(([date, dayEvents]) => (
-                                <div key={date} className="bg-white/60 rounded-lg p-3 border border-gray-200/50">
-                                  <div className="font-semibold text-gray-900 text-xs mb-1">{date}</div>
-                                  <div className="flex flex-wrap gap-2">
-                                    {dayEvents.map((event, idx) => {
-                                      const now = new Date();
-                                      const start = new Date(event.start_time);
-                                      const end = new Date(event.end_time);
-                                      const isCurrent = now >= start && now <= end;
-                                      
-                                      return (
-                                        <span 
-                                          key={idx}
-                                          className={`px-2 py-1 rounded text-xs font-medium ${
-                                            isCurrent 
-                                              ? 'bg-green-100/80 text-green-800 ring-1 ring-green-500/30' 
-                                              : 'bg-blue-100/80 text-blue-800'
-                                          }`}
-                                        >
-                                          {formatTime(event.start_time)}～{formatTime(event.end_time)}
-                                          {isCurrent && <span className="ml-1">●</span>}
-                                        </span>
-                                      );
-                                    })}
-                                  </div>
-                                </div>
-                              ))}
+
+                          <h3 className="text-xl font-bold text-gray-900 mb-2">
+                            {event.event?.name || 'イベントマッチ'}
+                          </h3>
+                          {event.event?.desc && (
+                            <p className="text-sm text-gray-700 mb-3 leading-relaxed">
+                              {event.event.desc}
+                            </p>
+                          )}
+
+                          <div className="space-y-3">
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                開催期間:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {formatEventPeriod(events)}
+                              </span>
                             </div>
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">ルール:</span>
-                            <span className="text-gray-700 font-bold">{event.rule?.name || '不明'}</span>
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">ステージ:</span>
-                            <span className="text-gray-700 font-bold">{stageNames}</span>
+                            <div className="text-sm">
+                              <span className="font-semibold text-gray-800 block mb-2">
+                                開催時間帯:
+                              </span>
+                              <div className="space-y-2">
+                                {Object.entries(groupEventsByDate(events)).map(
+                                  ([date, dayEvents]) => (
+                                    <div
+                                      key={date}
+                                      className="bg-white/60 rounded-lg p-3 border border-gray-200/50"
+                                    >
+                                      <div className="font-semibold text-gray-900 text-xs mb-1">
+                                        {date}
+                                      </div>
+                                      <div className="flex flex-wrap gap-2">
+                                        {dayEvents.map((event, idx) => {
+                                          const now = new Date();
+                                          const start = new Date(
+                                            event.start_time
+                                          );
+                                          const end = new Date(event.end_time);
+                                          const isCurrent =
+                                            now >= start && now <= end;
+
+                                          return (
+                                            <span
+                                              key={idx}
+                                              className={`px-2 py-1 rounded text-xs font-medium ${
+                                                isCurrent
+                                                  ? 'bg-green-100/80 text-green-800 ring-1 ring-green-500/30'
+                                                  : 'bg-blue-100/80 text-blue-800'
+                                              }`}
+                                            >
+                                              {formatTime(event.start_time)}～
+                                              {formatTime(event.end_time)}
+                                              {isCurrent && (
+                                                <span className="ml-1">●</span>
+                                              )}
+                                            </span>
+                                          );
+                                        })}
+                                      </div>
+                                    </div>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                ルール:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {event.rule?.name || '不明'}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                ステージ:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {stageNames}
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              }
+            )}
           </div>
         )}
       </section>
@@ -287,127 +351,175 @@ const EventMatchesView: React.FC<EventMatchesViewProps> = ({
 
         {upcomingEvents.length === 0 ? (
           <div className="bg-white/40 backdrop-blur-sm rounded-xl p-6 text-center border border-white/30 shadow-lg">
-            <p className="text-gray-600">今後のイベントマッチの予定はありません</p>
+            <p className="text-gray-600">
+              今後のイベントマッチの予定はありません
+            </p>
           </div>
         ) : (
           <div className="space-y-4">
-            {Object.entries(groupEventsByType(upcomingEvents)).slice(0, 5).map(([, events], groupIndex) => {
-              const event = events[0]; // 代表のイベント情報を使用
-              const eventTypeInfo = getEventTypeColor(event.event?.name);
-              const stageNames = event.stages?.map(stage => stage?.name || '不明').join(' / ') || '不明';
-              const stageImages = event.stages?.filter(stage => stage?.image).map(stage => stage.image) || [];
-              
-              const backgroundStyle = stageImages.length >= 2 ? {} : stageImages.length === 1 ? {
-                backgroundImage: `url('${stageImages[0]}')`,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
-                backgroundRepeat: 'no-repeat'
-              } : {};
+            {Object.entries(groupEventsByType(upcomingEvents))
+              .slice(0, 5)
+              .map(([, events], groupIndex) => {
+                const event = events[0]; // 代表のイベント情報を使用
+                const eventTypeInfo = getEventTypeColor(event.event?.name);
+                const stageNames =
+                  event.stages
+                    ?.map((stage) => stage?.name || '不明')
+                    .join(' / ') || '不明';
+                const stageImages =
+                  event.stages
+                    ?.filter((stage) => stage?.image)
+                    .map((stage) => stage.image) || [];
 
-              return (
-                <div 
-                  key={`upcoming-event-group-${groupIndex}`} 
-                  className={`rounded-xl p-6 shadow-md hover:shadow-lg transition-all duration-300 relative overflow-hidden ${stageImages.length > 0 ? '' : eventTypeInfo.bgColor}`}
-                  style={backgroundStyle}
-                >
-                  {/* 2つのステージの場合の背景 */}
-                  {stageImages.length >= 2 && (
-                    <>
-                      <div 
-                        className="absolute inset-0 rounded-xl opacity-80"
-                        style={{
+                const backgroundStyle =
+                  stageImages.length >= 2
+                    ? {}
+                    : stageImages.length === 1
+                      ? {
                           backgroundImage: `url('${stageImages[0]}')`,
                           backgroundSize: 'cover',
                           backgroundPosition: 'center',
                           backgroundRepeat: 'no-repeat',
-                          clipPath: 'polygon(0 0, 50% 0, 50% 100%, 0 100%)'
-                        }}
-                      />
-                      <div 
-                        className="absolute inset-0 rounded-xl opacity-80"
-                        style={{
-                          backgroundImage: `url('${stageImages[1]}')`,
-                          backgroundSize: 'cover',
-                          backgroundPosition: 'center',
-                          backgroundRepeat: 'no-repeat',
-                          clipPath: 'polygon(50% 0, 100% 0, 100% 100%, 50% 100%)'
-                        }}
-                      />
-                    </>
-                  )}
-                  
-                  {/* 可読性向上のためのオーバーレイ */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/60 to-white/50 backdrop-blur-xs rounded-xl"></div>
-                  
-                  {/* コンテンツ */}
-                  <div className="relative z-10">
-                    <div className="flex items-start justify-between mb-4">
-                      <div className="flex-1">
-                        <div className="mb-3">
-                          <span className={`px-4 py-2 rounded-full text-sm font-bold border-2 ${eventTypeInfo.color} bg-white shadow-xl`}>
-                            🎪 イベントマッチ
-                          </span>
-                        </div>
-                        
-                        <h3 className="text-xl font-bold text-gray-900 mb-2">{event.event?.name || 'イベントマッチ'}</h3>
-                        {event.event?.desc && (
-                          <p className="text-sm text-gray-700 mb-3 leading-relaxed">{event.event.desc}</p>
-                        )}
-                        
-                        <div className="space-y-3">
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">開催期間:</span>
-                            <span className="text-gray-700 font-bold">
-                              {formatEventPeriod(events)}
+                        }
+                      : {};
+
+                return (
+                  <div
+                    key={`upcoming-event-group-${groupIndex}`}
+                    className={`rounded-xl p-6 shadow-md hover:shadow-lg transition-all duration-300 relative overflow-hidden cursor-pointer ${stageImages.length > 0 ? '' : eventTypeInfo.bgColor}`}
+                    style={backgroundStyle}
+                    onClick={() => onEventCardClick?.(event)}
+                  >
+                    {/* 2つのステージの場合の背景 */}
+                    {stageImages.length >= 2 && (
+                      <>
+                        <div
+                          className="absolute inset-0 rounded-xl opacity-80"
+                          style={{
+                            backgroundImage: `url('${stageImages[0]}')`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                            clipPath: 'polygon(0 0, 50% 0, 50% 100%, 0 100%)',
+                          }}
+                        />
+                        <div
+                          className="absolute inset-0 rounded-xl opacity-80"
+                          style={{
+                            backgroundImage: `url('${stageImages[1]}')`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                            clipPath:
+                              'polygon(50% 0, 100% 0, 100% 100%, 50% 100%)',
+                          }}
+                        />
+                      </>
+                    )}
+
+                    {/* 可読性向上のためのオーバーレイ */}
+                    <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/60 to-white/50 backdrop-blur-xs rounded-xl"></div>
+
+                    {/* コンテンツ */}
+                    <div className="relative z-10">
+                      <div className="flex items-start justify-between mb-4">
+                        <div className="flex-1">
+                          <div className="mb-3">
+                            <span
+                              className={`px-4 py-2 rounded-full text-sm font-bold border-2 ${eventTypeInfo.color} bg-white shadow-xl`}
+                            >
+                              🎪 イベントマッチ
                             </span>
                           </div>
-                          <div className="text-sm">
-                            <span className="font-semibold text-gray-800 block mb-2">開催時間帯:</span>
-                            <div className="space-y-2">
-                              {Object.entries(groupEventsByDate(events)).map(([date, dayEvents]) => (
-                                <div key={date} className="bg-white/60 rounded-lg p-3 border border-gray-200/50">
-                                  <div className="font-semibold text-gray-900 text-xs mb-1">{date}</div>
-                                  <div className="flex flex-wrap gap-2">
-                                    {dayEvents.map((event, idx) => {
-                                      const now = new Date();
-                                      const start = new Date(event.start_time);
-                                      const end = new Date(event.end_time);
-                                      const isCurrent = now >= start && now <= end;
-                                      
-                                      return (
-                                        <span 
-                                          key={idx}
-                                          className={`px-2 py-1 rounded text-xs font-medium ${
-                                            isCurrent 
-                                              ? 'bg-green-100/80 text-green-800 ring-1 ring-green-500/30' 
-                                              : 'bg-blue-100/80 text-blue-800'
-                                          }`}
-                                        >
-                                          {formatTime(event.start_time)}～{formatTime(event.end_time)}
-                                          {isCurrent && <span className="ml-1">●</span>}
-                                        </span>
-                                      );
-                                    })}
-                                  </div>
-                                </div>
-                              ))}
+
+                          <h3 className="text-xl font-bold text-gray-900 mb-2">
+                            {event.event?.name || 'イベントマッチ'}
+                          </h3>
+                          {event.event?.desc && (
+                            <p className="text-sm text-gray-700 mb-3 leading-relaxed">
+                              {event.event.desc}
+                            </p>
+                          )}
+
+                          <div className="space-y-3">
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                開催期間:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {formatEventPeriod(events)}
+                              </span>
                             </div>
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">ルール:</span>
-                            <span className="text-gray-700 font-bold">{event.rule?.name || '不明'}</span>
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="font-semibold text-gray-800">ステージ:</span>
-                            <span className="text-gray-700 font-bold">{stageNames}</span>
+                            <div className="text-sm">
+                              <span className="font-semibold text-gray-800 block mb-2">
+                                開催時間帯:
+                              </span>
+                              <div className="space-y-2">
+                                {Object.entries(groupEventsByDate(events)).map(
+                                  ([date, dayEvents]) => (
+                                    <div
+                                      key={date}
+                                      className="bg-white/60 rounded-lg p-3 border border-gray-200/50"
+                                    >
+                                      <div className="font-semibold text-gray-900 text-xs mb-1">
+                                        {date}
+                                      </div>
+                                      <div className="flex flex-wrap gap-2">
+                                        {dayEvents.map((event, idx) => {
+                                          const now = new Date();
+                                          const start = new Date(
+                                            event.start_time
+                                          );
+                                          const end = new Date(event.end_time);
+                                          const isCurrent =
+                                            now >= start && now <= end;
+
+                                          return (
+                                            <span
+                                              key={idx}
+                                              className={`px-2 py-1 rounded text-xs font-medium ${
+                                                isCurrent
+                                                  ? 'bg-green-100/80 text-green-800 ring-1 ring-green-500/30'
+                                                  : 'bg-blue-100/80 text-blue-800'
+                                              }`}
+                                            >
+                                              {formatTime(event.start_time)}～
+                                              {formatTime(event.end_time)}
+                                              {isCurrent && (
+                                                <span className="ml-1">●</span>
+                                              )}
+                                            </span>
+                                          );
+                                        })}
+                                      </div>
+                                    </div>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                ルール:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {event.rule?.name || '不明'}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm">
+                              <span className="font-semibold text-gray-800">
+                                ステージ:
+                              </span>
+                              <span className="text-gray-700 font-bold">
+                                {stageNames}
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
           </div>
         )}
       </section>

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -917,10 +917,22 @@ const ConditionSection: React.FC<ConditionSectionProps> = ({
     }
   };
 
+  const handleClearAll = () => {
+    onSelectionChange([]);
+  };
+
   return (
     <div>
       <div className="flex items-center gap-4 mb-3">
         <label className="text-sm font-medium">{title}</label>
+        {selectedValues.length > 0 && (
+          <button
+            onClick={handleClearAll}
+            className="text-xs text-blue-500 hover:text-blue-700 underline"
+          >
+            全て外す
+          </button>
+        )}
       </div>
 
       <div

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -693,7 +693,7 @@ const BasicMatchConditionEditor: React.FC<BasicMatchConditionEditorProps> = ({
 };
 
 // イベントマッチ条件編集モーダル
-interface EventMatchConditionEditorProps {
+export interface EventMatchConditionEditorProps {
   condition: NotificationCondition | null;
   allStages: Array<{ id: string; name: string }>;
   eventTypes: string[];
@@ -703,13 +703,9 @@ interface EventMatchConditionEditorProps {
   onCancel: () => void;
 }
 
-const EventMatchConditionEditor: React.FC<EventMatchConditionEditorProps> = ({
-  condition,
-  allStages,
-  eventTypes,
-  onSave,
-  onCancel,
-}) => {
+export const EventMatchConditionEditor: React.FC<
+  EventMatchConditionEditorProps
+> = ({ condition, allStages, eventTypes, onSave, onCancel }) => {
   const [formData, setFormData] = useState(() => ({
     name: condition?.name || '',
     enabled: condition?.enabled ?? true,

--- a/src/utils/conditionNameGenerator.ts
+++ b/src/utils/conditionNameGenerator.ts
@@ -8,6 +8,7 @@ export interface GenerateConditionNameParams {
   rules: string[];
   matchTypes: string[];
   stages: string[];
+  eventName?: string;
 }
 
 /**
@@ -16,13 +17,20 @@ export interface GenerateConditionNameParams {
  * - 複数項目は同じ種類内でスラッシュ区切り
  * - 異なる種類間はカンマ区切り
  * - レギュラーマッチは表示しない
+ * - イベントマッチの場合はイベント名を前に付ける
  */
 export function generateConditionName({
   rules,
   matchTypes,
   stages,
+  eventName,
 }: GenerateConditionNameParams): string {
   const parts: string[] = [];
+
+  // イベント名がある場合は最初に追加
+  if (eventName) {
+    parts.push(eventName);
+  }
 
   // ルール部分を追加
   if (rules.length > 0) {

--- a/src/utils/eventMatchToCondition.ts
+++ b/src/utils/eventMatchToCondition.ts
@@ -30,11 +30,11 @@ export const eventMatchToCondition = (
     enabled: true,
     stages: {
       operator: 'OR',
-      values: stageIds,
+      values: [], // イベントマッチでは通常のステージは使わない
     },
     rules: {
       operator: 'OR',
-      values: [ruleName],
+      values: [], // イベントマッチでは通常のルールは使わない
     },
     matchTypes: {
       operator: 'OR',

--- a/src/utils/eventMatchToCondition.ts
+++ b/src/utils/eventMatchToCondition.ts
@@ -1,10 +1,4 @@
-import {
-  EventMatch,
-  NotificationCondition,
-  GameRule,
-  MatchType,
-} from '../types';
-import { generateConditionName } from './conditionNameGenerator';
+import { EventMatch, NotificationCondition, MatchType } from '../types';
 
 /**
  * イベントマッチから通知条件データを生成する
@@ -12,18 +6,10 @@ import { generateConditionName } from './conditionNameGenerator';
 export const eventMatchToCondition = (
   match: EventMatch
 ): Partial<NotificationCondition> => {
-  const stageIds = match.stages.map((stage) => stage.id);
-  const stageNames = match.stages.map((stage) => stage.name);
-  const ruleName = match.rule.name as GameRule;
   const eventName = match.event.name;
 
-  // 条件名を自動生成（イベント情報を含める）
-  const conditionName = generateConditionName({
-    rules: [ruleName],
-    matchTypes: ['イベントマッチ'],
-    stages: stageNames,
-    eventName: eventName,
-  });
+  // 条件名を自動生成（イベント名のみ）
+  const conditionName = eventName;
 
   const condition: Partial<NotificationCondition> = {
     name: conditionName,
@@ -48,7 +34,7 @@ export const eventMatchToCondition = (
       },
       eventStages: {
         operator: 'OR',
-        values: stageIds,
+        values: [], // イベントステージは選択しない
       },
     },
     notifyMinutesBefore: 10, // デフォルトの通知タイミング

--- a/src/utils/eventMatchToCondition.ts
+++ b/src/utils/eventMatchToCondition.ts
@@ -1,0 +1,58 @@
+import {
+  EventMatch,
+  NotificationCondition,
+  GameRule,
+  MatchType,
+} from '../types';
+import { generateConditionName } from './conditionNameGenerator';
+
+/**
+ * イベントマッチから通知条件データを生成する
+ */
+export const eventMatchToCondition = (
+  match: EventMatch
+): Partial<NotificationCondition> => {
+  const stageIds = match.stages.map((stage) => stage.id);
+  const stageNames = match.stages.map((stage) => stage.name);
+  const ruleName = match.rule.name as GameRule;
+  const eventName = match.event.name;
+
+  // 条件名を自動生成（イベント情報を含める）
+  const conditionName = generateConditionName({
+    rules: [ruleName],
+    matchTypes: ['イベントマッチ'],
+    stages: stageNames,
+    eventName: eventName,
+  });
+
+  const condition: Partial<NotificationCondition> = {
+    name: conditionName,
+    enabled: true,
+    stages: {
+      operator: 'OR',
+      values: stageIds,
+    },
+    rules: {
+      operator: 'OR',
+      values: [ruleName],
+    },
+    matchTypes: {
+      operator: 'OR',
+      values: ['イベントマッチ' as MatchType],
+    },
+    eventMatches: {
+      enabled: true,
+      eventTypes: {
+        operator: 'OR',
+        values: [eventName],
+      },
+      eventStages: {
+        operator: 'OR',
+        values: stageIds,
+      },
+    },
+    notifyMinutesBefore: 10, // デフォルトの通知タイミング
+  };
+
+  return condition;
+};


### PR DESCRIPTION
## 概要
イベントマッチタブから通知条件を作成できる機能を実装しました。
スケジュールタブと同様に、イベントカードをタップすると通知条件設定ダイアログが開き、イベント情報が自動で選択状態になります。

## 主な変更点
- EventMatchからNotificationConditionへの変換関数を作成
- EventMatchesViewにクリック機能を追加してカーソルをpointerに変更
- App.tsxでイベントマッチのクリックハンドリングを追加
- 通知ダイアログでイベントマッチの条件自動入力に対応
- 条件名生成でイベント名を含めるように拡張

## 関連Issue
Closes #62

🤖 Generated with [Claude Code](https://claude.ai/code)